### PR TITLE
docker: define client cert auth env variables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
     environment:
       TESTXMPP_COORDINATOR_URI: "tcp://127.0.0.1:5001"
       TESTXMPP_S2S_FROM: tbd.dreckshal.de
+      TESTXMPP_S2S_CLIENT_CERT: ""
+      TESTXMPP_S2S_CLIENT_KEY: ""
   web:
     image: testxmpp/web:latest
     build:


### PR DESCRIPTION
4e18ee1b268447ce1ba262ff4048536401b6f5b7 adds support for client cert authentication.

With this support, a couple of new environment variables need to be defined. Without them,
`docker-compose up` complains.

```
xmpp_1         | Traceback (most recent call last):
xmpp_1         |   File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
xmpp_1         |     return _run_code(code, main_globals, None,
xmpp_1         |   File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
xmpp_1         |     exec(code, run_globals)
xmpp_1         |   File "/usr/local/lib/python3.9/dist-packages/testxmpp/xmpp/__main__.py", line 2, in <module>
xmpp_1         |     testxmpp.xmpp.cli.main()
xmpp_1         |   File "/usr/local/lib/python3.9/dist-packages/testxmpp/xmpp/cli.py", line 60, in main
xmpp_1         |     config = environ.to_config(AppConfig)
xmpp_1         |   File "/usr/local/lib/python3.9/dist-packages/environ/_environ_config.py", line 218, in to_config
xmpp_1         |     return _to_config(config_cls, default_get, environ, ())
xmpp_1         |   File "/usr/local/lib/python3.9/dist-packages/environ/_environ_config.py", line 230, in _to_config
xmpp_1         |     val = get(environ, a.metadata, prefix, a.name)
xmpp_1         |   File "/usr/local/lib/python3.9/dist-packages/environ/_environ_config.py", line 215, in default_get
xmpp_1         |     raise MissingEnvValueError(var)
xmpp_1         | environ.exceptions.MissingEnvValueError: TESTXMPP_S2S_CLIENT_CERT
```