### PR TITLE
Documentation: Change web port from 5000 to 8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A re-implementation of the original [xmppoke](https://github.com/xmpp-observatory/xmppoke/)-based XMPP observatory in Python, based on [testssl.sh](https://testssl.sh).
 
-Currently, this isn't quite ready for the stage yet, but if you want to play, you should be able to get quite far with `docker-compose up` and then navigating to `http://localhost:5000`. If your user ID is not 1000, you might have to change the docker-compose file so that it can read/write the testing SQLite database.
+Currently, this isn't quite ready for the stage yet, but if you want to play, you should be able to get quite far with `docker-compose up` and then navigating to `http://localhost:8000`. If your user ID is not 1000, you might have to change the docker-compose file so that it can read/write the testing SQLite database.


### PR DESCRIPTION
When running docker-compose up, the webserver seems to be exposed at port 8000:

```
web_1          | [2022-04-26 17:16:14 +0000] [1] [INFO] Running on http://[::]:8000 (CTRL + C to quit)
```