### PR TITLE
Support running without s2s certs

### DIFF
--- a/testxmpp/xmpp/cli.py
+++ b/testxmpp/xmpp/cli.py
@@ -14,8 +14,8 @@ from .daemon import XMPPWorker
 class AppConfig:
     coordinator_uri = environ.var("tcp://localhost:5001")
     s2s_from = environ.var()
-    s2s_client_cert = environ.var()
-    s2s_client_key = environ.var()
+    s2s_client_cert = environ.var(default=None)
+    s2s_client_key = environ.var(default=None)
 
 
 async def amain(coordinator_uri, s2s_from, s2s_client_cert, s2s_client_key):

--- a/testxmpp/xmpp/daemon.py
+++ b/testxmpp/xmpp/daemon.py
@@ -75,10 +75,15 @@ async def scan_xmpp(domain: aioxmpp.JID,
             OpenSSL.SSL.VERIFY_PEER,
             aioxmpp.security_layer.default_verify_callback,
         )
-        if client_cert_path:
+        if client_cert_path is not None:
             ssl_context.use_certificate_chain_file(client_cert_path)
-        if client_key_path:
+        if client_key_path is not None:
             ssl_context.use_privatekey_file(client_key_path)
+        if protocol == "s2s" and client_key_path is None:
+            logging.warn(
+                "running s2s tests without client certificate may"
+                " be inaccurate or cause false negatives"
+            )
         verifier.setup_context(ssl_context, transport)
         return ssl_context
 
@@ -244,10 +249,10 @@ async def scan_features(domain: aioxmpp.JID,
 
 
 class XMPPWorker(testxmpp.common.Worker):
-    def __init__(self, coordinator_uri,
-                 s2s_from,
-                 s2s_client_cert,
-                 s2s_client_key):
+    def __init__(self, coordinator_uri: str,
+                 s2s_from: str,
+                 s2s_client_cert: typing.Optional[str],
+                 s2s_client_key: typing.Optional[str]):
         super().__init__(coordinator_uri, logging.getLogger(__name__))
         self._s2s_from = s2s_from
         self._s2s_client_cert = s2s_client_cert


### PR DESCRIPTION
This is a different approach to #4; in #4, the default was set to the
empty string, which is ambiguous. In addition, it was unclear what the
use-case would be, because I was being dense.

If the tool is exclusively used for c2s testing, s2s certs don't matter;
their lack should not prevent the tool from starting up. In addition,
s2s certs are not needed for all s2s cases either: for instance, testing
hosts with dialback support is still possible without s2s certs.