### PR TITLE
testxmpp: Fix unwrapping PEMs

### DIFF
--- a/testxmpp/certutil.py
+++ b/testxmpp/certutil.py
@@ -106,6 +106,7 @@ def unwrap_pem(blob: str) -> bytes:
     blob = blob[(startidx+len(HEAD)):]
     endidx = blob.find(FOOT)
     blob = blob[:endidx]
+    blob = blob.strip(r"\n")
     return base64.b64decode(blob)
 
 


### PR DESCRIPTION
While testing I saw multiple certs with line breaks (`\n`) after "-----BEGIN CERTIFICATE-----" and before "-----END CERTIFICATE-----". This PR strips those `\n`s and unwraps PEMs correctly.